### PR TITLE
String template with expressions

### DIFF
--- a/runtime/parser/expression.go
+++ b/runtime/parser/expression.go
@@ -1191,10 +1191,6 @@ func defineStringExpression() {
 					if err != nil {
 						return nil, err
 					}
-					// limit string templates to identifiers only
-					if _, ok := value.(*ast.IdentifierExpression); !ok {
-						return nil, p.syntaxError("expected identifier got: %s", value.String())
-					}
 					_, err = p.mustOne(lexer.TokenParenClose)
 					if err != nil {
 						return nil, err

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -6198,7 +6198,7 @@ func TestParseStringTemplate(t *testing.T) {
 		)
 	})
 
-	t.Run("invalid, num", func(t *testing.T) {
+	t.Run("valid, num", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -6213,16 +6213,7 @@ func TestParseStringTemplate(t *testing.T) {
 			}
 		}
 
-		require.Error(t, err)
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "expected identifier got: 2 + 2",
-					Pos:     ast.Position{Offset: 13, Line: 2, Column: 12},
-				},
-			},
-			errs,
-		)
+		require.NoError(t, err)
 	})
 
 	t.Run("valid, nested identifier", func(t *testing.T) {
@@ -6291,7 +6282,7 @@ func TestParseStringTemplate(t *testing.T) {
 		)
 	})
 
-	t.Run("invalid, function identifier", func(t *testing.T) {
+	t.Run("valid, function identifier", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -6306,16 +6297,7 @@ func TestParseStringTemplate(t *testing.T) {
 			}
 		}
 
-		require.Error(t, err)
-		utils.AssertEqualWithDiff(t,
-			[]error{
-				&SyntaxError{
-					Message: "expected identifier got: add()",
-					Pos:     ast.Position{Offset: 12, Line: 2, Column: 11},
-				},
-			},
-			errs,
-		)
+		require.NoError(t, err)
 	})
 
 	t.Run("unbalanced paren", func(t *testing.T) {

--- a/runtime/parser/expression_test.go
+++ b/runtime/parser/expression_test.go
@@ -6300,7 +6300,7 @@ func TestParseStringTemplate(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("unbalanced paren", func(t *testing.T) {
+	t.Run("invalid, missing paren", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -6327,7 +6327,34 @@ func TestParseStringTemplate(t *testing.T) {
 		)
 	})
 
-	t.Run("nested templates", func(t *testing.T) {
+	t.Run("invalid, nested expression paren", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, errs := testParseExpression(`
+			"\((2+2)/2()"
+		`)
+
+		var err error
+		if len(errs) > 0 {
+			err = Error{
+				Errors: errs,
+			}
+		}
+
+		require.Error(t, err)
+		utils.AssertEqualWithDiff(t,
+			[]error{
+				&SyntaxError{
+					Message: "expected token ')'",
+					Pos:     ast.Position{Offset: 16, Line: 2, Column: 15},
+				},
+			},
+			errs,
+		)
+	})
+
+	t.Run("invalid, nested templates", func(t *testing.T) {
 
 		t.Parallel()
 
@@ -6352,6 +6379,45 @@ func TestParseStringTemplate(t *testing.T) {
 			},
 			errs,
 		)
+	})
+
+	t.Run("valid, extra closing paren", func(t *testing.T) {
+
+		t.Parallel()
+
+		actual, errs := testParseExpression(`
+			"\(a))"
+		`)
+
+		var err error
+		if len(errs) > 0 {
+			err = Error{
+				Errors: errs,
+			}
+		}
+
+		require.NoError(t, err)
+
+		expected := &ast.StringTemplateExpression{
+			Values: []string{
+				"",
+				")",
+			},
+			Expressions: []ast.Expression{
+				&ast.IdentifierExpression{
+					Identifier: ast.Identifier{
+						Identifier: "a",
+						Pos:        ast.Position{Offset: 7, Line: 2, Column: 6},
+					},
+				},
+			},
+			Range: ast.Range{
+				StartPos: ast.Position{Offset: 4, Line: 2, Column: 3},
+				EndPos:   ast.Position{Offset: 10, Line: 2, Column: 9},
+			},
+		}
+
+		utils.AssertEqualWithDiff(t, expected, actual)
 	})
 }
 

--- a/runtime/tests/checker/string_test.go
+++ b/runtime/tests/checker/string_test.go
@@ -742,6 +742,27 @@ func TestCheckStringTemplate(t *testing.T) {
 		assert.IsType(t, &sema.TypeMismatchWithDescriptionError{}, errs[0])
 	})
 
+	t.Run("invalid, struct with tostring", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			access(all)
+			struct SomeStruct {
+				access(all)
+				view fun toString(): String {
+					return "SomeStruct"
+				}
+			}
+			let a = SomeStruct()
+			let x: String = "\(a)" 
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchWithDescriptionError{}, errs[0])
+	})
+
 	t.Run("invalid, array", func(t *testing.T) {
 		t.Parallel()
 
@@ -781,6 +802,20 @@ func TestCheckStringTemplate(t *testing.T) {
 				destroy x
 				return y
 			} 
+		`)
+
+		errs := RequireCheckerErrors(t, err, 1)
+
+		assert.IsType(t, &sema.TypeMismatchWithDescriptionError{}, errs[0])
+	})
+
+	t.Run("invalid, expression type", func(t *testing.T) {
+
+		t.Parallel()
+
+		_, err := ParseAndCheck(t, `
+			let y: Int = 0
+			let x: String = "\(y > 0 ? "String" : true)"
 		`)
 
 		errs := RequireCheckerErrors(t, err, 1)

--- a/runtime/tests/interpreter/interpreter_test.go
+++ b/runtime/tests/interpreter/interpreter_test.go
@@ -12412,4 +12412,53 @@ func TestInterpretStringTemplates(t *testing.T) {
 			inter.Globals.Get("x").GetValue(inter),
 		)
 	})
+
+	t.Run("func", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let add = fun(): Int {
+				return 2+2
+			}
+			let x: String = "\(add())"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("4"),
+			inter.Globals.Get("x").GetValue(inter),
+		)
+	})
+
+	t.Run("ternary", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let z = false
+			let x: String = "\(z ? "foo" : "bar" )"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("bar"),
+			inter.Globals.Get("x").GetValue(inter),
+		)
+	})
+
+	t.Run("nested", func(t *testing.T) {
+		t.Parallel()
+
+		inter := parseCheckAndInterpret(t, `
+			let x: String = "\(2*(4-2) + 1 == 5)"
+		`)
+
+		AssertValuesEqual(
+			t,
+			inter,
+			interpreter.NewUnmeteredStringValue("true"),
+			inter.Globals.Get("x").GetValue(inter),
+		)
+	})
 }


### PR DESCRIPTION
Working towards https://github.com/onflow/cadence/issues/3579
Based off https://github.com/onflow/cadence/pull/3585

## Description

<!--
Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

Removes the limitation imposed in https://github.com/onflow/cadence/pull/3585 of forcing identifier only in string templates.

______

<!-- Complete: -->

- [ ] Targeted PR against `identifier-string-template` branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [ ] Code follows the [standards mentioned here](https://github.com/onflow/cadence/blob/master/CONTRIBUTING.md#styleguides)
- [ ] Updated relevant documentation 
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 
